### PR TITLE
feat: Dynamic IP

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,7 +28,7 @@ func NewFromFile(path string) (*Config, error) {
 		return nil, fmt.Errorf("unmarshal: %w", err)
 	}
 
-	return c, nil
+	return c, c.Validate()
 }
 
 // Config is the configuration for the exporter
@@ -40,11 +40,30 @@ type Config struct {
 
 // Server is a DayZ server endpoint
 type Server struct {
-	IP   string `yaml:"ip"`
-	Port int    `yaml:"port"`
+	Name       string `yaml:"name"`
+	IP         string `yaml:"ip"`
+	Port       int    `yaml:"port"`
+	OverrideIP bool   `yaml:"override_ip"`
 }
 
 // String returns the server as a string
 func (s Server) String() string {
 	return net.JoinHostPort(s.IP, strconv.Itoa(s.Port))
+}
+
+// Validate validates the configuration
+func (c *Config) Validate() error {
+	if c.Interval < time.Second*30 {
+		return fmt.Errorf("interval must be at least 30 seconds: %s", c.Interval)
+	}
+
+	if len(c.Servers) == 0 {
+		return fmt.Errorf("no servers defined")
+	}
+
+	if c.Host == "" {
+		return fmt.Errorf("host is required")
+	}
+
+	return nil
 }

--- a/internal/ifconfig/ifconfig.go
+++ b/internal/ifconfig/ifconfig.go
@@ -1,0 +1,142 @@
+// Package ifconfig is used to detect the public
+// ip address of the host
+package ifconfig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+const (
+	endpoint = "https://ifconfig.net/json"
+
+	clientRequestTimeout = 30 * time.Second
+)
+
+// Response is the response from the ifconfig.net service
+type Response struct {
+	IP         string  `json:"ip"`
+	IPDecimal  int     `json:"ip_decimal"`
+	Country    string  `json:"country"`
+	CountryIso string  `json:"country_iso"`
+	CountryEu  bool    `json:"country_eu"`
+	Latitude   float64 `json:"latitude"`
+	Longitude  float64 `json:"longitude"`
+	TimeZone   string  `json:"time_zone"`
+	Asn        string  `json:"asn"`
+	AsnOrg     string  `json:"asn_org"`
+	Hostname   string  `json:"hostname"`
+	UserAgent  struct {
+		Product  string `json:"product"`
+		Version  string `json:"version"`
+		Comment  string `json:"comment"`
+		RawValue string `json:"raw_value"`
+	} `json:"user_agent"`
+}
+
+// New takes a HTTP client creates a new ifconfig client
+func New(logger *zap.Logger) Client {
+	return Client{
+		client: &http.Client{
+			Timeout: clientRequestTimeout,
+		},
+		logger: logger,
+	}
+}
+
+// Client is the ifconfig client
+type Client struct {
+	client  *http.Client
+	logger  *zap.Logger
+	address string
+	mu      sync.Mutex
+}
+
+// Get gets the public ip address of the host
+func (c *Client) Get() (*Response, error) {
+	resp := Response{}
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	}
+
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return nil, err
+	}
+
+	return &resp, nil
+}
+
+// Start starts the ifconfig client loop
+func (c *Client) Start(ctx context.Context) error {
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+
+	resp, err := c.Get()
+	if err != nil {
+		return fmt.Errorf("startup get: %w", err)
+	}
+
+	if resp.IP == "" {
+		return fmt.Errorf("empty ip address")
+	}
+
+	c.mu.Lock()
+	c.address = resp.IP
+	c.mu.Unlock()
+
+	c.logger.Info("public ip address updated", zap.String("ip", resp.IP))
+
+	c.logger.Info("starting request loop")
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				resp, err := c.Get()
+				if err != nil {
+					c.logger.Error("get", zap.Error(err))
+					continue
+				}
+
+				if resp.IP == "" {
+					c.logger.Error("empty ip address")
+					continue
+				}
+
+				c.mu.Lock()
+				c.address = resp.IP
+				c.mu.Unlock()
+				c.logger.Debug("public ip address updated", zap.String("ip", resp.IP))
+
+			case <-ctx.Done():
+				c.logger.Info("shutting down")
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+// GetAddress gets the public ip address of the host
+func (c *Client) GetAddress() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.address
+}

--- a/model/model.go
+++ b/model/model.go
@@ -57,3 +57,9 @@ type Result struct {
 	Vac              bool     `json:"vac"`
 	Version          string   `json:"version"`
 }
+
+// QueryError is the error response from the DZSA API
+type QueryError struct {
+	Status int    `json:"status"`
+	Error  string `json:"error"`
+}

--- a/package/config.yaml
+++ b/package/config.yaml
@@ -4,15 +4,15 @@ interval: 60s
 servers:
   # First Light servers
   # 
-  # Deer Isle
-  - ip: "50.108.13.235"
+  - name: "Deer Isle"
+    ip: "50.108.13.235"
     port: 2424
-  # Deer Isle Hardcore
-  - ip: "50.108.13.235"
+  - name: Deer Isle Hardcore
+    ip: "50.108.13.235"
     port: 2324
-  # Namalsk Hardcore
-  - ip: "50.108.13.235"
+  - name: Namalsk Hardcore
+    ip: "50.108.13.235"
     port: 2315
-  # Frostline
-  - ip: "50.108.13.235"
+  - name: Frostline
+    ip: "50.108.13.235"
     port: 27016


### PR DESCRIPTION
Dynamic IP allows the exporter to detect the public ip. This is useful for environments where the public ip could change. Usage of the override option will mean the exporter must be running within the same network as the dayz servers being monitored. Override is configured on a per server basis.